### PR TITLE
TAG を打った時の build で version を tag 名にする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,3 +39,12 @@ jobs:
           paths:
             - "~/.gradle"
             - "~/.m2"
+
+workflows:
+  version: 2
+  all:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -18,6 +18,9 @@ ext {
 version = LocalDateTime.now().format("yyyyMMdd") + "-" + revision +
 		(git.branch.current.name != "master" ? "-SNAPSHOT" : "") +
 		(git.status().isClean() ? "" : "+dirty")
+if (System.getenv('CIRCLE_TAG') != null) {
+	version = System.getenv('CIRCLE_TAG')
+}
 
 task showVersion {
 	doLast {


### PR DESCRIPTION
この対応で version は以下のようになる

* feature branch : yyyyMMdd-hash-SNAPSHOT
    * snapshot として publish
* master branch へ merge: yyyyMMdd
    * release として publish
* tag 打った場合: tag 名
    * release として publish


tag(2.16.1) を打った時の CI https://circleci.com/gh/classmethod/baseunits/10

依存関係にある spar-wings の build において、baseunits の version を 2.16.1 を指定した時
![スクリーンショット 2020-03-17 14 12 26](https://user-images.githubusercontent.com/26866755/76824127-802c8200-6859-11ea-93ad-d660ee0fca8a.png)

release 側を見てる